### PR TITLE
Fix Nav and contact form having same z-index

### DIFF
--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -2,7 +2,7 @@
   background: white;
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   border-bottom: 1px solid var(--lightGrey);
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.025);
 }


### PR DESCRIPTION
The top nav bar has the same z-index as the contact form. This means that the nav bar will not be over the form when scrolling down.