### PR TITLE
fix: format post date widget value

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -294,7 +294,7 @@ collections: # A list of collections the CMS should be able to edit
         widget: 'select'
         options: ['Published', 'Featured', 'Draft']
         default: 'Published'
-      - { label: Date / Order, name: date, widget: date }
+      - { label: Date / Order, name: date, widget: date, format: 'YYYY-MM-DD' }
       - {
           label: Featured Image,
           name: featuredImage,


### PR DESCRIPTION
See https://github.com/netlify/netlify-cms/issues/3651#issuecomment-620485179
Existing posts use a format of `YYYY-MM-DD`:
https://github.com/thriveweb/yellowcake/blame/master/content/posts/2018-05-25-testing-1-8-2.md#L5
For new posts the date will be serialised as a date object which breaks the preview template here:
https://github.com/thriveweb/yellowcake/blob/b0084a4a082ee48a25c09e8c52fcc1de52a628e1/src/templates/SinglePost.js#L36