### PR TITLE
fixed readme to give correct location of file to edit for CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are adding or editing content locally in the CMS, a couple of things to n
 
 ## Editing CMS fields
 
-The Netlify CMS configuration is located in `public/admin/config.yml`. This is where you will configure the pages, fields, posts and settings that are editable by the CMS.
+The Netlify CMS configuration is located in `static/admin/config.yml`. This is where you will configure the pages, fields, posts and settings that are editable by the CMS.
 
 Find out more in the [Netlify CMS Docs](https://www.netlifycms.org/docs/#configuration).
 


### PR DESCRIPTION
The current README file is not correct when it tells users to go to "Public/admin/config.yml" this file will be deleted upon running gatsby clean or on every new build. 

Users should be going to "static/admin/config.yml" to make permanent changes to the CMS. I correct the readme to say this. 